### PR TITLE
Fix flipped data

### DIFF
--- a/regular_mesh_plotter/core.py
+++ b/regular_mesh_plotter/core.py
@@ -132,6 +132,8 @@ def plot_regular_mesh_tally_with_geometry(
         )
     else:
         values = get_values_from_tally(tally)
+        if source_strength is not None:
+            values = tuple(val*source_strength for val in values)
 
     value = get_std_dev_or_value_from_tally(tally, values, std_dev_or_tally_value)
 

--- a/regular_mesh_plotter/core.py
+++ b/regular_mesh_plotter/core.py
@@ -132,8 +132,6 @@ def plot_regular_mesh_tally_with_geometry(
         )
     else:
         values = get_values_from_tally(tally)
-        if source_strength is not None:
-            values = tuple(val * source_strength for val in values)
 
     value = get_std_dev_or_value_from_tally(tally, values, std_dev_or_tally_value)
 

--- a/regular_mesh_plotter/core.py
+++ b/regular_mesh_plotter/core.py
@@ -42,10 +42,17 @@ def plot_regular_mesh_values(
         rot = transforms.Affine2D().rotate_deg_around(x_center, y_center, rotate_plot)
 
         image_map = plt.imshow(
-            values, norm=scale, vmin=vmin, extent=extent, transform=rot + base, origin="lower"
+            values,
+            norm=scale,
+            vmin=vmin,
+            extent=extent,
+            transform=rot + base,
+            origin="lower",
         )
     else:
-        image_map = plt.imshow(values, norm=scale, vmin=vmin, extent=extent, origin="lower")
+        image_map = plt.imshow(
+            values, norm=scale, vmin=vmin, extent=extent, origin="lower"
+        )
 
     plt.xlabel(x_label)
     plt.ylabel(y_label)

--- a/regular_mesh_plotter/core.py
+++ b/regular_mesh_plotter/core.py
@@ -133,7 +133,7 @@ def plot_regular_mesh_tally_with_geometry(
     else:
         values = get_values_from_tally(tally)
         if source_strength is not None:
-            values = tuple(val*source_strength for val in values)
+            values = tuple(val * source_strength for val in values)
 
     value = get_std_dev_or_value_from_tally(tally, values, std_dev_or_tally_value)
 

--- a/regular_mesh_plotter/core.py
+++ b/regular_mesh_plotter/core.py
@@ -42,10 +42,10 @@ def plot_regular_mesh_values(
         rot = transforms.Affine2D().rotate_deg_around(x_center, y_center, rotate_plot)
 
         image_map = plt.imshow(
-            values, norm=scale, vmin=vmin, extent=extent, transform=rot + base
+            values, norm=scale, vmin=vmin, extent=extent, transform=rot + base, origin="lower"
         )
     else:
-        image_map = plt.imshow(values, norm=scale, vmin=vmin, extent=extent)
+        image_map = plt.imshow(values, norm=scale, vmin=vmin, extent=extent, origin="lower")
 
     plt.xlabel(x_label)
     plt.ylabel(y_label)


### PR DESCRIPTION
This PR fixes the flipping of the y data due to imshow default behaviour of putting the origin at the top